### PR TITLE
Auth 기능에 대해 Windows, macOS 플랫폼 Alwayson 필드 활성화

### DIFF
--- a/GamebaseSettingTool/adapterData.json
+++ b/GamebaseSettingTool/adapterData.json
@@ -105,10 +105,12 @@
                             }
                         },
                         {
-                            "name" : "Windows"
+                            "name" : "Windows",
+                            "alwaysOn" : true
                         },
                         {
-                            "name" : "macOS"
+                            "name" : "macOS",
+                            "alwaysOn" : true
                         }
                     ]
                 },
@@ -129,10 +131,12 @@
                             }
                         },
                         {
-                            "name" : "Windows"
+                            "name" : "Windows",
+                            "alwaysOn" : true
                         },
                         {
-                            "name" : "macOS"
+                            "name" : "macOS",
+                            "alwaysOn" : true
                         }
                     ]
                 },
@@ -180,10 +184,12 @@
                             }
                         },
                         {
-                            "name" : "Windows"
+                            "name" : "Windows",
+                            "alwaysOn" : true
                         },
                         {
-                            "name" : "macOS"
+                            "name" : "macOS",
+                            "alwaysOn" : true
                         }
                     ]
                 },
@@ -204,10 +210,12 @@
                             }
                         },
                         {
-                            "name" : "Windows"
+                            "name" : "Windows",
+                            "alwaysOn" : true
                         },
                         {
-                            "name" : "macOS"
+                            "name" : "macOS",
+                            "alwaysOn" : true
                         }
                     ]
                 },
@@ -236,10 +244,12 @@
                             }
                         },
                         {
-                            "name" : "Windows"
+                            "name" : "Windows",
+                            "alwaysOn" : true
                         },
                         {
-                            "name" : "macOS"
+                            "name" : "macOS",
+                            "alwaysOn" : true
                         }
                     ]
                 },
@@ -260,10 +270,12 @@
                             }
                         },
                         {
-                            "name" : "Windows"
+                            "name" : "Windows",
+                            "alwaysOn" : true
                         },
                         {
-                            "name" : "macOS"
+                            "name" : "macOS",
+                            "alwaysOn" : true
                         }
                     ]
                 },
@@ -320,10 +332,12 @@
                             }
                         },
                         {
-                            "name" : "Windows"
+                            "name" : "Windows",
+                            "alwaysOn" : true
                         },
                         {
-                            "name" : "macOS"
+                            "name" : "macOS",
+                            "alwaysOn" : true
                         }
                     ]
                 },
@@ -378,10 +392,12 @@
                     "displayName": "Epic Games",
                     "platforms" : [
                         {
-                            "name" : "Windows"
+                            "name" : "Windows",
+                            "alwaysOn" : true
                         },
                         {
-                            "name" : "macOS"
+                            "name" : "macOS",
+                            "alwaysOn" : true
                         }
                     ]
                 }


### PR DESCRIPTION
Windows and macOS entries for Facebook, Google, Naver, Twitter, Line, AppleId, Payco, and EpicGames now set `"alwaysOn": true`. These platforms are always supported by the Auth adapters and the Setting Tool UI renders them as disabled+checked (cannot be deselected).

Requires SettingTool build with the alwaysOn schema support.